### PR TITLE
Added Username and Password for MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ included in many distributions yet.
 You can generate an RPM package with cpack:
 ```
 sudo wget -P /etc/yum.repos.d/ http://download.opensuse.org/repositories/home:/oojah:/mqtt/CentOS_CentOS-$(awk -v RS=[0-9]+ '{print RT+0;exit}' /etc/redhat-release)/home:oojah:mqtt.repo
-sudo yum -y install cmake ipset-devel libmosquitto-devel '@Development Tools'
+sudo yum -y install cmake ipset-devel libmosquitto-devel pkgconfig '@Development Tools'
 
 git clone https://github.com/stintel/vallumd.git
 cd vallumd
@@ -64,8 +64,7 @@ Tested on CentOS 6 and 7.
 
 You can generate a DEB package with cpack:
 ```
-sudo apt-get -y install build-essential cmake libipset-dev libmosquitto-dev
-
+sudo apt-get -y install build-essential cmake libipset-dev libmosquitto-dev pkg-config
 git clone https://github.com/stintel/vallumd.git
 cd vallumd
 cmake .
@@ -131,7 +130,9 @@ Now you can start vallumd. The following command line options exist:
 ```
  -h: MQTT host to connect to
  -p: MQTT port to connect to (1883)
+ -P: MQTT password
  -t: MQTT topic and IPset name
+ -u: MQTT username
  -V: print version number and exit
 ```
 The host and topic options are required, the others are optional (default

--- a/src/main.c
+++ b/src/main.c
@@ -28,21 +28,25 @@
 
 static void print_usage()
 {
-    printf("Usage: -h host [-p port] -t topic1 [-t topicN]\n");
+    printf("Usage: -h host [-p port] [-P password] -t topic1 [-t topicN] [-u username]\n");
     printf(" -h: MQTT host to connect to\n");
     printf(" -p: MQTT port to connect to (1883)\n");
+    printf(" -P: MQTT password\n");    
     printf(" -t: MQTT topic and IPset name\n");
+    printf(" -u: MQTT username\n");
     printf(" -V: print version number and exit\n");
 }
 
 int main(int argc, char **argv)
 {
     char *host = NULL;
+    char *username = NULL;
+    char *password = NULL;
     int opt = 0;
     unsigned int port = 1883;
     unsigned int t = 0;
 
-    while ((opt = getopt(argc, argv, "h:p:t:V")) != -1) {
+    while ((opt = getopt(argc, argv, "h:p:P:t:u:V")) != -1) {
         if (opt == 't') {
             ntopics++;
         }
@@ -51,7 +55,7 @@ int main(int argc, char **argv)
     mqtt_topics = malloc(ntopics * sizeof(*mqtt_topics));
 
     optind = 0;
-    while ((opt = getopt(argc, argv, "h:p:t:V")) != -1) {
+    while ((opt = getopt(argc, argv, "h:p:P:t:u:V")) != -1) {
         switch (opt) {
             case 'h':
                 host = optarg;
@@ -59,10 +63,16 @@ int main(int argc, char **argv)
             case 'p':
                 port = atoi(optarg);
                 break;
+            case 'P':
+                password = optarg;
+                break;
             case 't':
                 mqtt_topics[t] = malloc((strlen(optarg) + 1) * sizeof(char));
                 strcpy(mqtt_topics[t], optarg);
                 t++;
+                break;
+            case 'u':
+                username = optarg;
                 break;
             case 'V':
                 fprintf(stdout, "vallumd-%s\n", VERSION);
@@ -80,6 +90,8 @@ int main(int argc, char **argv)
 
     mqtt_host = host;
     mqtt_port = port;
+    mqtt_username = username;
+    mqtt_password = password;
 
     init_mqtt();
 

--- a/src/mosquitto.c
+++ b/src/mosquitto.c
@@ -28,6 +28,8 @@
 
 char *mqtt_host;
 char **mqtt_topics;
+char *mqtt_username;
+char *mqtt_password;
 int mqtt_port;
 unsigned int ntopics;
 
@@ -78,6 +80,7 @@ int init_mqtt()
 
     mosquitto_connect_callback_set(m, cb_con);
     mosquitto_message_callback_set(m, cb_msg);
+    mosquitto_username_pw_set(m, mqtt_username, mqtt_password);
 
     mosquitto_connect(m, mqtt_host, mqtt_port, keepalive);
 

--- a/src/mosquitto.h
+++ b/src/mosquitto.h
@@ -20,6 +20,8 @@
 
 extern char *mqtt_host;
 extern char **mqtt_topics;
+extern char *mqtt_username;
+extern char *mqtt_password;
 extern int mqtt_port;
 extern unsigned int ntopics;
 


### PR DESCRIPTION
I added Username and Password for basic MQTT authentication for security reasons (so that we can at least use an basic protection on our server and the acl features of MQTT).